### PR TITLE
Cached UI mode (light / dark) on reload

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,16 +47,17 @@
   </body>
   <script src="index.js"></script>
   <script>
-    function toggle_light_mode() {
+    function toggle_light_mode(firstLoad) {
         var app = document.getElementsByTagName("BODY")[0];
-        if (localStorage.lightMode == "dark") {
-      localStorage.lightMode = "light";
-      app.setAttribute("light-mode", "light");
-      showmsg('Light Mode Enabled.')
-    } else {
-      localStorage.lightMode = "dark";
-      app.setAttribute("light-mode", "dark");
-      showmsg('Dark Mode Enabled.')
+        const check = firstLoad ? localStorage.lightMode != "dark" : localStorage.lightMode == "dark";
+        if (check) {
+          localStorage.lightMode = "light";
+          app.setAttribute("light-mode", "light");
+          if (!firstLoad) showmsg('Light Mode Enabled.')
+        } else {
+          localStorage.lightMode = "dark";
+          app.setAttribute("light-mode", "dark");
+          if (!firstLoad) showmsg('Dark Mode Enabled.')
         }		
     }
 
@@ -66,5 +67,11 @@
         maggio.classList.add('show');
         setTimeout(function(){maggio.classList.remove('show')},3000);
     };
+    document.onreadystatechange = () => {
+      if (document.readyState === 'complete') {
+        console.log('Flipped!');
+        toggle_light_mode({});
+      }
+    }
     </script>
 </html>


### PR DESCRIPTION
Reloading the page now maintains the previous UI mode, i.e. dark remains dark on reload and vice versa. Contributes to #48.

![mini-todo-dark-mode](https://user-images.githubusercontent.com/15625446/198550514-6d84129d-7ee7-43e3-a759-c8febb8c14db.gif)

Please add the `hacktoberfest-accepted` label if you like it!